### PR TITLE
Fixed API functions

### DIFF
--- a/customStyles.js
+++ b/customStyles.js
@@ -4,6 +4,7 @@ exports.customStyles = {
   endpoints: ["customStyles.styles.new","customStyles.styles.update", "customStyles.styles.globalDisable", "customStyles.styles.disable", "customStyles.styles.delete", "customStyles.styles.get", "customStyles.styles.stylesForPad", "customStyles.styles.allStyles", "customStyles.styles.disabledStyles"],
   styles: {
     new: function(styleId, css, padId, cb){
+      console.warn("New style:", styleId, css, padId);
       // console.log("Creating new Style", styleId, css, padId || false);
       db.get("custom_style_css_"+styleId, function(err, alreadyExists){
         console.warn("alreadyExists", alreadyExists);
@@ -79,7 +80,12 @@ exports.customStyles = {
     },
     setStylesForPad: function(padId, styleIds, cb){
       // console.log("Setting StyleIds for PadId", padId, styleIds);
+      var styleIdsType = Object.prototype.toString.call(styleIds);
+      if(styleIdsType === "[object String]") {
+        styleIds = [styleIds];
+      }
       db.set("custom_style_association_"+padId, styleIds);
+      cb(null, "set styles!");
     },
     allStyles: function(cb){
       // console.log("Getting all available Styles");

--- a/customStyles.js
+++ b/customStyles.js
@@ -4,7 +4,6 @@ exports.customStyles = {
   endpoints: ["customStyles.styles.new","customStyles.styles.update", "customStyles.styles.globalDisable", "customStyles.styles.disable", "customStyles.styles.delete", "customStyles.styles.get", "customStyles.styles.stylesForPad", "customStyles.styles.allStyles", "customStyles.styles.disabledStyles"],
   styles: {
     new: function(styleId, css, padId, cb){
-      console.warn("New style:", styleId, css, padId);
       // console.log("Creating new Style", styleId, css, padId || false);
       db.get("custom_style_css_"+styleId, function(err, alreadyExists){
         console.warn("alreadyExists", alreadyExists);

--- a/index.js
+++ b/index.js
@@ -12,7 +12,14 @@ var getEndPoints = [
   "customStyles.styles.get",
   "customStyles.styles.stylesForPad",
   "customStyles.styles.allStyles",
-  "customStyles.styles.disabledStyles"
+  "customStyles.styles.disabledStyles",
+  "customStyles.styles.new",
+  "customStyles.styles.update",
+  "customStyles.styles.globalDisable",
+  "customStyles.styles.disable",
+  "customStyles.styles.delete",
+  "customStyles.styles.setStylesForPad"
+
 ];
 
 var setEndPoints = [
@@ -43,7 +50,7 @@ exports.registerRoute = function (hook_name, args, callback) {
       // object of requested params = req.query
 
       if(method === "new"){
-        customStyles.styles[method](req.query.styleId, req.query.css, req.padId, function(err, value){
+        customStyles.styles[method](req.query.styleId, req.query.css, req.query.padId, function(err, value){ //this was using req.padId, which wasn't working
           if(err) console.error(err);
           res.send(value);
         });
@@ -92,7 +99,7 @@ exports.registerRoute = function (hook_name, args, callback) {
       }
 
       if(method === "setStylesForPad"){
-        customStyles.styles[method](req.query.padId, styleIds, function(err, value){
+        customStyles.styles[method](req.query.padId, req.query.styleIds, function(err, value){
           if(err) console.error(err);
           res.send(value);
         });

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
           fs = require('fs'),
        async = require('ep_etherpad-lite/node_modules/async'),
    Changeset = require("ep_etherpad-lite/static/js/Changeset"),
-    settings = require('ep_etherpad-lite/src/node/utils/Settings'),
+    settings = require('ep_etherpad-lite/node/utils/Settings'),
 customStyles = require('./customStyles').customStyles;
 
 // Remove cache for this procedure


### PR DESCRIPTION
At least, I think I did. Let me know what you think of my solution. 

I added all of the setEndPoints to the getEndPoints array, since the code mapping the getEndPoints already had functions to handle those endpoints.

I fixed a couple of what I think were typos where req was being used instead of req.query 

For the setStylesForPad method we'll need to update the API documentation. The problem was with passing in arrays as a parameter. The method documented in the API doc wasn't working because the value of any single parameter gets passed to the function by Express as a string. However, if the same parameter is included multiple times with multiple values, Express handily builds an array and passes them off. In other words: 

http://localhost:9001/pluginAPI/customStyles.styles.setStylesForPad?apikey=seekrit&styleIds=["style1", "style2"]&padId=stylesTest

wouldn't work because styleId would end up a string "["style1","style2"]" 

However if we use:

http://localhost:9001/pluginAPI/customStyles.styles.setStylesForPad?apikey=seekrit&styleIds=style1&styleIds=style2&padId=stylesTest

Then Express gives us ["style1","style2"] for req.styleIds and everything works. 

For the case in which only a single styleIds parameter is used, I wrote a little test to see if req.styleIds is a string, and if it is, wraps it in an array. 

Tell me what you think!
- Andy
